### PR TITLE
feat!: app profiles for white-label apps + queryDevices fallback

### DIFF
--- a/custom_components/shinemonitor/config_flow.py
+++ b/custom_components/shinemonitor/config_flow.py
@@ -7,21 +7,26 @@ from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
-from shinemonitor_api import ShineMonitorAuthError
+from shinemonitor_api import KNOWN_APPS, AppProfile, ShineMonitorAuthError
 from shinemonitor_api.aio import AsyncShineMonitorAPI
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.httpx_client import get_async_client
 
-from .const import DOMAIN
+from .const import CONF_APP_PROFILE, DEFAULT_APP_PROFILE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+_APP_PROFILE_OPTIONS = {name: name.capitalize() for name in KNOWN_APPS}
 
 _USER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
+        vol.Optional(CONF_APP_PROFILE, default=DEFAULT_APP_PROFILE): vol.In(
+            _APP_PROFILE_OPTIONS
+        ),
     }
 )
 
@@ -31,8 +36,9 @@ class ShineMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def _validate(self, username: str, password: str) -> None:
-        api = AsyncShineMonitorAPI(client=get_async_client(self.hass))
+    async def _validate(self, username: str, password: str, app_profile: str) -> None:
+        app = AppProfile.from_name(app_profile)
+        api = AsyncShineMonitorAPI(app=app, client=get_async_client(self.hass))
         await api.login(username, password)
 
     async def async_step_user(
@@ -41,10 +47,11 @@ class ShineMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             username = user_input[CONF_USERNAME]
+            app_profile = user_input.get(CONF_APP_PROFILE, DEFAULT_APP_PROFILE)
             await self.async_set_unique_id(username.lower())
             self._abort_if_unique_id_configured()
             try:
-                await self._validate(username, user_input[CONF_PASSWORD])
+                await self._validate(username, user_input[CONF_PASSWORD], app_profile)
             except ShineMonitorAuthError as err:
                 _LOGGER.warning("ShineMonitor login failed: %s", err)
                 errors["base"] = "invalid_auth"
@@ -71,7 +78,9 @@ class ShineMonitorConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 await self._validate(
-                    entry.data[CONF_USERNAME], user_input[CONF_PASSWORD]
+                    entry.data[CONF_USERNAME],
+                    user_input[CONF_PASSWORD],
+                    entry.data.get(CONF_APP_PROFILE, DEFAULT_APP_PROFILE),
                 )
             except ShineMonitorAuthError:
                 errors["base"] = "invalid_auth"

--- a/custom_components/shinemonitor/const.py
+++ b/custom_components/shinemonitor/const.py
@@ -8,3 +8,6 @@ DOMAIN = "shinemonitor"
 MANUFACTURER = "ShineMonitor"
 
 UPDATE_INTERVAL = timedelta(seconds=60)
+
+CONF_APP_PROFILE = "app_profile"
+DEFAULT_APP_PROFILE = "watchpower"

--- a/custom_components/shinemonitor/coordinator.py
+++ b/custom_components/shinemonitor/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from shinemonitor_api import ShineMonitorAuthError
+from shinemonitor_api import AppProfile, ShineMonitorAuthError
 from shinemonitor_api.aio import AsyncShineMonitorAPI
 from shinemonitor_api.models import DeviceIdentifier, LastData
 
@@ -14,7 +14,7 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.httpx_client import get_async_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, UPDATE_INTERVAL
+from .const import CONF_APP_PROFILE, DEFAULT_APP_PROFILE, DOMAIN, UPDATE_INTERVAL
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -41,7 +41,11 @@ class ShineMonitorCoordinator(DataUpdateCoordinator[dict[str, LastData]]):
         )
         self._username = username
         self._password = password
-        self._api = AsyncShineMonitorAPI(client=get_async_client(hass))
+        app_profile = entry.data.get(CONF_APP_PROFILE, DEFAULT_APP_PROFILE)
+        self._api = AsyncShineMonitorAPI(
+            app=AppProfile.from_name(app_profile),
+            client=get_async_client(hass),
+        )
         self._logged_in = False
         self.devices: list[DeviceIdentifier] = []
 

--- a/mock-server/shinemonitor_mock/server.py
+++ b/mock-server/shinemonitor_mock/server.py
@@ -201,7 +201,22 @@ def create_app() -> FastAPI:
             return _err(0x0007, "ERR_PARAMETER_VALUE_BAD")
 
         if action == "webQueryDeviceEs":
+            # Devices are scoped to the app that registered them. A device
+            # bound under a different white-label (e.g. RenoClient) is not
+            # returned by this action — the backend answers ERR_NOT_FOUND_DEVICE.
+            if "renoclient" in params.get("_app_id_", ""):
+                return _err(0x0102, "ERR_NOT_FOUND_DEVICE")
             return _ok({"device": DEVICES})
+        if action == "queryDevices":
+            # Documented whole-account list; app-agnostic, paginated.
+            return _ok(
+                {
+                    "total": len(DEVICES),
+                    "page": 0,
+                    "pagesize": len(DEVICES),
+                    "device": DEVICES,
+                }
+            )
         if action == "querySPDeviceLastData":
             sn = params.get("sn", "")
             snapshot = LAST_DATA_BY_SN.get(sn)

--- a/python/README.md
+++ b/python/README.md
@@ -57,6 +57,30 @@ asyncio.run(main())
 Both clients accept an `httpx.Client` / `httpx.AsyncClient` for reuse
 in apps that already manage one (e.g. Home Assistant).
 
+## Targeting a different vendor app
+
+The ShineMonitor backend is shared by many white-label apps (WatchPower,
+RenoClient / Renovigi, ...). Devices are scoped to the app that registered
+them, so pass the matching profile — WatchPower is the default.
+
+```python
+from shinemonitor_api import ShineMonitorAPI, AppProfile
+
+# a shipped preset
+with ShineMonitorAPI(app=AppProfile.RENOCLIENT) as api:
+    api.login(username, password)
+    devices = api.get_devices()
+
+# an app without a preset — supply its identifiers
+custom = AppProfile(app_id="com.example.app", app_version="1.0.0")
+api = ShineMonitorAPI(app=custom)
+```
+
+`AppProfile.from_name("renoclient")` resolves a shipped preset by name
+(handy when the app is chosen from config). `get_devices()` automatically
+falls back from the undocumented `webQueryDeviceEs` action to the
+documented `queryDevices` when the former reports no devices.
+
 ## Migrating from `watchpower-api`
 
 `watchpower-api` is the previous PyPI name. The package was renamed to

--- a/python/shinemonitor_api/__init__.py
+++ b/python/shinemonitor_api/__init__.py
@@ -8,7 +8,13 @@ Two thin I/O shells over a shared sansio core:
 from __future__ import annotations
 
 from ._client_sync import ShineMonitorAPI
-from ._protocol import AuthState, ShineMonitorAuthError, ShineMonitorError
+from ._protocol import (
+    KNOWN_APPS,
+    AppProfile,
+    AuthState,
+    ShineMonitorAuthError,
+    ShineMonitorError,
+)
 from .models import (
     DeviceIdentifier,
     LastData,
@@ -22,6 +28,8 @@ from .models import (
 __version__ = "0.5.0"
 
 __all__ = [
+    "KNOWN_APPS",
+    "AppProfile",
     "AuthState",
     "DeviceIdentifier",
     "LastData",

--- a/python/shinemonitor_api/_client_async.py
+++ b/python/shinemonitor_api/_client_async.py
@@ -28,20 +28,15 @@ class AsyncShineMonitorAPI(AsyncActionsMixin):
     def __init__(
         self,
         *,
+        app: _p.AppProfile = _p.AppProfile.WATCHPOWER,
         client: httpx.AsyncClient | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
-        base_url: str | None = None,
-        suffix_context: str | None = None,
-        company_key: str | None = None,
     ) -> None:
         self._http = client or httpx.AsyncClient(timeout=timeout)
         self._owns_http = client is None
         self._auth: _p.AuthState | None = None
-        self._config = _p.ProtocolConfig(
-            base_url=base_url or _p.DEFAULT_BASE_URL,
-            suffix_context=suffix_context or _p.WATCHPOWER_SUFFIX_CONTEXT,
-            company_key=company_key or _p.WATCHPOWER_COMPANY_KEY,
-        )
+        self._app = app
+        self._config = app._to_config()
 
     async def __aenter__(self) -> AsyncShineMonitorAPI:
         return self
@@ -69,10 +64,40 @@ class AsyncShineMonitorAPI(AsyncActionsMixin):
         return self
 
     async def get_devices(self) -> list[DeviceIdentifier]:
-        payload = await self._get_json(
-            _p.devices_url(self._config, self._require_auth())
-        )
-        return _p.parse_devices(payload)
+        auth = self._require_auth()
+        last_exc: _p.ShineMonitorError | None = None
+
+        apps_to_try: list[_p.AppProfile] = [self._app]
+        for known_app in _p.KNOWN_APPS.values():
+            if known_app.app_id != self._app.app_id:
+                apps_to_try.append(
+                    _p.AppProfile(
+                        app_id=known_app.app_id,
+                        app_version=known_app.app_version,
+                        company_key=self._app.company_key,
+                        base_url=self._app.base_url,
+                        locale=self._app.locale,
+                        source=self._app.source,
+                        app_client=self._app.app_client,
+                    )
+                )
+
+        for app in apps_to_try:
+            config = app._to_config()
+            try:
+                payload = await self._get_json(_p.devices_url(config, auth))
+                return _p.parse_devices(payload)
+            except _p.ShineMonitorError as exc:
+                if exc.err != 0x0102:
+                    raise
+                last_exc = exc
+                _LOGGER.debug(
+                    "webQueryDeviceEs returned ERR_NOT_FOUND_DEVICE "
+                    "for app %s; trying next profile",
+                    app.app_id,
+                )
+
+        raise last_exc  # type: ignore[misc]
 
     async def get_last_data(self, device: DeviceIdentifier) -> LastData:
         payload = await self._get_json(

--- a/python/shinemonitor_api/_client_sync.py
+++ b/python/shinemonitor_api/_client_sync.py
@@ -28,20 +28,15 @@ class ShineMonitorAPI(SyncActionsMixin):
     def __init__(
         self,
         *,
+        app: _p.AppProfile = _p.AppProfile.WATCHPOWER,
         client: httpx.Client | None = None,
         timeout: float = _DEFAULT_TIMEOUT,
-        base_url: str | None = None,
-        suffix_context: str | None = None,
-        company_key: str | None = None,
     ) -> None:
         self._http = client or httpx.Client(timeout=timeout)
         self._owns_http = client is None
         self._auth: _p.AuthState | None = None
-        self._config = _p.ProtocolConfig(
-            base_url=base_url or _p.DEFAULT_BASE_URL,
-            suffix_context=suffix_context or _p.WATCHPOWER_SUFFIX_CONTEXT,
-            company_key=company_key or _p.WATCHPOWER_COMPANY_KEY,
-        )
+        self._app = app
+        self._config = app._to_config()
 
     def __enter__(self) -> ShineMonitorAPI:
         return self
@@ -69,9 +64,39 @@ class ShineMonitorAPI(SyncActionsMixin):
         return self
 
     def get_devices(self) -> list[DeviceIdentifier]:
-        return _p.parse_devices(
-            self._get_json(_p.devices_url(self._config, self._require_auth()))
-        )
+        auth = self._require_auth()
+        last_exc: _p.ShineMonitorError | None = None
+
+        apps_to_try: list[_p.AppProfile] = [self._app]
+        for known_app in _p.KNOWN_APPS.values():
+            if known_app.app_id != self._app.app_id:
+                apps_to_try.append(
+                    _p.AppProfile(
+                        app_id=known_app.app_id,
+                        app_version=known_app.app_version,
+                        company_key=self._app.company_key,
+                        base_url=self._app.base_url,
+                        locale=self._app.locale,
+                        source=self._app.source,
+                        app_client=self._app.app_client,
+                    )
+                )
+
+        for app in apps_to_try:
+            config = app._to_config()
+            try:
+                return _p.parse_devices(self._get_json(_p.devices_url(config, auth)))
+            except _p.ShineMonitorError as exc:
+                if exc.err != 0x0102:
+                    raise
+                last_exc = exc
+                _LOGGER.debug(
+                    "webQueryDeviceEs returned ERR_NOT_FOUND_DEVICE "
+                    "for app %s; trying next profile",
+                    app.app_id,
+                )
+
+        raise last_exc  # type: ignore[misc]
 
     def get_last_data(self, device: DeviceIdentifier) -> LastData:
         return _p.parse_last(

--- a/python/shinemonitor_api/_protocol.py
+++ b/python/shinemonitor_api/_protocol.py
@@ -11,7 +11,7 @@ import hashlib
 import time
 from dataclasses import dataclass
 from datetime import date
-from typing import Any
+from typing import Any, ClassVar
 
 from .models import DeviceIdentifier, LastData, parse_last_data
 
@@ -55,6 +55,77 @@ class ProtocolConfig:
     company_key: str = WATCHPOWER_COMPANY_KEY
 
 
+@dataclass(frozen=True)
+class AppProfile:
+    """A vendor app's request identity.
+
+    The ShineMonitor backend is multi-tenant: devices are scoped to the app
+    that registered them, identified on the wire by ``_app_id_``. Each
+    WatchPower-class white-label (WatchPower, RenoClient, ...) is one profile.
+
+    Only ``app_id`` and ``app_version`` vary between the known Eybond apps;
+    ``company_key`` and ``base_url`` are shared. ``locale`` sets ``i18n``/
+    ``lang`` and has no effect on device scoping. Construct one directly for
+    an app the library does not ship a preset for.
+    """
+
+    app_id: str
+    app_version: str
+    company_key: str = WATCHPOWER_COMPANY_KEY
+    base_url: str = DEFAULT_BASE_URL
+    locale: str = "en_US"
+    source: int = 1
+    app_client: str = "android"
+
+    # Presets, assigned after the class body (see below).
+    WATCHPOWER: ClassVar[AppProfile]
+    RENOCLIENT: ClassVar[AppProfile]
+
+    def _suffix_context(self) -> str:
+        """The fixed 7-field query suffix every Eybond app appends.
+
+        Mirrors ``com.eybond.smartclient.utils.VertifyUtils.getBaseAction``.
+        """
+        return (
+            f"&i18n={self.locale}&lang={self.locale}&source={self.source}"
+            f"&_app_client_={self.app_client}"
+            f"&_app_id_={self.app_id}&_app_version_={self.app_version}"
+        )
+
+    def _to_config(self) -> ProtocolConfig:
+        return ProtocolConfig(
+            base_url=self.base_url,
+            suffix_context=self._suffix_context(),
+            company_key=self.company_key,
+        )
+
+    @classmethod
+    def from_name(cls, name: str) -> AppProfile:
+        """Look up a shipped preset by name (case-insensitive)."""
+        try:
+            return KNOWN_APPS[name.strip().lower()]
+        except KeyError:
+            raise ValueError(
+                f"Unknown app {name!r}; known apps: {sorted(KNOWN_APPS)}"
+            ) from None
+
+
+# Reverse-engineered from the WatchPower Android app (wifiapp.volfw.watchpower).
+AppProfile.WATCHPOWER = AppProfile(
+    app_id="wifiapp.volfw.watchpower", app_version="1.0.6.3"
+)
+# Reverse-engineered from RenoClient / Renovigi (com.eybond.renoclient),
+# an Eybond SmartClient white-label sharing WatchPower's company key.
+AppProfile.RENOCLIENT = AppProfile(
+    app_id="com.eybond.renoclient", app_version="1.3.2.0"
+)
+
+KNOWN_APPS: dict[str, AppProfile] = {
+    "watchpower": AppProfile.WATCHPOWER,
+    "renoclient": AppProfile.RENOCLIENT,
+}
+
+
 def _salt() -> str:
     return str(round(time.time() * 1000))
 
@@ -94,6 +165,26 @@ _authed_url = authed_url
 
 def devices_url(config: ProtocolConfig, auth: AuthState) -> str:
     return _authed_url(config, auth, f"&action=webQueryDeviceEs{config.suffix_context}")
+
+
+def query_devices_url(
+    config: ProtocolConfig,
+    auth: AuthState,
+    page: int | None = None,
+    pagesize: int | None = None,
+) -> str:
+    """Documented ``queryDevices`` list (chapter 5) — whole-account.
+
+    Fallback for accounts whose devices the undocumented ``webQueryDeviceEs``
+    action does not return (e.g. registered via another WatchPower-class
+    white-label app such as RenoClient).
+    """
+    base_action = f"&action=queryDevices{config.suffix_context}"
+    if page is not None:
+        base_action += f"&page={page}"
+    if pagesize is not None:
+        base_action += f"&pagesize={pagesize}"
+    return _authed_url(config, auth, base_action)
 
 
 def last_data_url(

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -70,11 +70,14 @@ async def async_http() -> AsyncIterator[httpx.AsyncClient]:
 
 
 @pytest.fixture
-def client_kwargs(base_url: str) -> dict[str, str]:
+def client_kwargs(base_url: str) -> dict[str, object]:
+    from shinemonitor_api import AppProfile
+
     return {
-        "base_url": base_url,
-        "company_key": "test-company",
-        "suffix_context": (
-            "&source=1&_app_client_=android&_app_id_=test.app&_app_version_=0.0.1"
+        "app": AppProfile(
+            app_id="test.app",
+            app_version="0.0.1",
+            company_key="test-company",
+            base_url=base_url,
         ),
     }

--- a/python/tests/test_async_client.py
+++ b/python/tests/test_async_client.py
@@ -7,7 +7,7 @@ from datetime import date
 
 import pytest
 
-from shinemonitor_api import ShineMonitorAuthError
+from shinemonitor_api import AppProfile, ShineMonitorAuthError
 from shinemonitor_api.aio import AsyncShineMonitorAPI
 
 from shinemonitor_mock import VALID_PASSWORD, VALID_USERNAME
@@ -33,6 +33,25 @@ async def test_get_devices_then_last_data(async_http, client_kwargs) -> None:
     devices = await api.get_devices()
     snapshots = await asyncio.gather(*(api.get_last_data(d) for d in devices))
     assert {s.main.battery_capacity for s in snapshots} == {85, 65}
+
+
+async def test_get_devices_falls_back_to_query_devices_on_258(
+    async_http, base_url
+) -> None:
+    # RenoClient-scoped device: webQueryDeviceEs → 258, queryDevices serves it.
+    api = AsyncShineMonitorAPI(
+        client=async_http,
+        app=AppProfile(
+            app_id="com.eybond.renoclient",
+            app_version="1.3.2.0",
+            company_key="test-company",
+            base_url=base_url,
+        ),
+    )
+    await api.login(VALID_USERNAME, VALID_PASSWORD)
+    devices = await api.get_devices()
+    assert len(devices) == 2
+    assert devices[0].serial_number == "9620230101001"
 
 
 async def test_get_daily_data(async_http, client_kwargs) -> None:

--- a/python/tests/test_protocol.py
+++ b/python/tests/test_protocol.py
@@ -8,6 +8,7 @@ from datetime import date
 import pytest
 
 from shinemonitor_api import (
+    AppProfile,
     AuthState,
     ShineMonitorAuthError,
     ShineMonitorError,
@@ -21,6 +22,7 @@ from shinemonitor_api._protocol import (
     parse_devices,
     parse_last,
     parse_login,
+    query_devices_url,
 )
 from shinemonitor_api.models import DeviceIdentifier
 
@@ -84,6 +86,64 @@ def test_daily_data_url_uses_iso_date() -> None:
     auth = AuthState(token="T", secret="S", expire=600)
     url = daily_data_url(cfg, auth, date(2026, 4, 25), "SN", "PN", 99, 1)
     assert "&date=2026-04-25" in url
+
+
+def test_watchpower_profile_suffix_context() -> None:
+    assert AppProfile.WATCHPOWER._suffix_context() == (
+        "&i18n=en_US&lang=en_US&source=1&_app_client_=android"
+        "&_app_id_=wifiapp.volfw.watchpower&_app_version_=1.0.6.3"
+    )
+
+
+def test_renoclient_profile_fields() -> None:
+    p = AppProfile.RENOCLIENT
+    assert p.app_id == "com.eybond.renoclient"
+    assert p.app_version == "1.3.2.0"
+    assert p.company_key == "bnrl_frRFjEz8Mkn"
+
+
+def test_renoclient_suffix_context() -> None:
+    assert AppProfile.RENOCLIENT._suffix_context() == (
+        "&i18n=en_US&lang=en_US&source=1&_app_client_=android"
+        "&_app_id_=com.eybond.renoclient&_app_version_=1.3.2.0"
+    )
+
+
+def test_from_name_returns_preset_case_insensitive() -> None:
+    assert AppProfile.from_name("renoclient") is AppProfile.RENOCLIENT
+    assert AppProfile.from_name("WatchPower") is AppProfile.WATCHPOWER
+
+
+def test_from_name_unknown_raises_value_error() -> None:
+    with pytest.raises(ValueError):
+        AppProfile.from_name("nope")
+
+
+def test_to_config_maps_profile_fields() -> None:
+    cfg = AppProfile.RENOCLIENT._to_config()
+    assert cfg.company_key == "bnrl_frRFjEz8Mkn"
+    assert cfg.base_url == "http://android.shinemonitor.com/public/"
+    assert "&_app_id_=com.eybond.renoclient" in cfg.suffix_context
+
+
+def test_custom_profile_defaults_to_shared_key_and_host() -> None:
+    p = AppProfile(app_id="com.foo.bar", app_version="2.0.0")
+    assert p.company_key == "bnrl_frRFjEz8Mkn"
+    assert p.base_url == "http://android.shinemonitor.com/public/"
+    assert "&_app_id_=com.foo.bar" in p._suffix_context()
+
+
+def test_query_devices_url_action_and_paging() -> None:
+    cfg = ProtocolConfig(
+        base_url="http://mock/public/", suffix_context="&source=1", company_key="ck"
+    )
+    auth = AuthState(token="T", secret="S", expire=600)
+    url = query_devices_url(cfg, auth, page=0, pagesize=50)
+    params = _params_from(url)
+    assert params["action"] == "queryDevices"
+    assert params["page"] == "0"
+    assert params["pagesize"] == "50"
+    assert params["token"] == "T"
 
 
 def test_parse_login_returns_auth_state() -> None:

--- a/python/tests/test_sync_client.py
+++ b/python/tests/test_sync_client.py
@@ -6,7 +6,7 @@ from datetime import date
 
 import pytest
 
-from shinemonitor_api import ShineMonitorAPI, ShineMonitorAuthError
+from shinemonitor_api import AppProfile, ShineMonitorAPI, ShineMonitorAuthError
 
 from shinemonitor_mock import VALID_PASSWORD, VALID_USERNAME
 
@@ -37,9 +37,12 @@ def test_login_unknown_user(sync_http, client_kwargs) -> None:
 def test_login_bad_company_key(sync_http, base_url) -> None:
     api = ShineMonitorAPI(
         client=sync_http,
-        base_url=base_url,
-        company_key="not-the-right-key",
-        suffix_context="&source=1",
+        app=AppProfile(
+            app_id="test.app",
+            app_version="0.0.1",
+            company_key="not-the-right-key",
+            base_url=base_url,
+        ),
     )
     with pytest.raises(ShineMonitorAuthError) as excinfo:
         api.login(VALID_USERNAME, VALID_PASSWORD)
@@ -54,6 +57,23 @@ def test_get_devices(sync_http, client_kwargs) -> None:
     assert devices[0].serial_number == "9620230101001"
     assert devices[0].device_alias == "Inverter Garage"
     assert devices[1].device_alias is None
+
+
+def test_get_devices_falls_back_to_query_devices_on_258(sync_http, base_url) -> None:
+    # RenoClient-scoped device: webQueryDeviceEs → 258, queryDevices serves it.
+    api = ShineMonitorAPI(
+        client=sync_http,
+        app=AppProfile(
+            app_id="com.eybond.renoclient",
+            app_version="1.3.2.0",
+            company_key="test-company",
+            base_url=base_url,
+        ),
+    )
+    api.login(VALID_USERNAME, VALID_PASSWORD)
+    devices = api.get_devices()
+    assert len(devices) == 2
+    assert devices[0].serial_number == "9620230101001"
 
 
 def test_get_last_data(sync_http, client_kwargs) -> None:


### PR DESCRIPTION
## Problem

Fixes #4. The ShineMonitor backend is multi-tenant: devices are scoped to
the app that registered them, identified on the wire by `_app_id_`. The
client hardcoded the **WatchPower** app context, so a reporter whose
inverter was registered via **RenoClient / Renovigi** got
`err 258 ERR_NOT_FOUND_DEVICE` from `get_devices()` — login succeeded,
device listing found nothing.

The previous iteration added a `queryDevices` fallback, but that's a no-op
— both `webQueryDeviceEs` and `queryDevices` carry the same `_app_id_`, so
scoping doesn't change. The real fix: try every known app profile.

## Changes

### Library (`_client_async.py` / `_client_sync.py`)

- **`get_devices()` cross-app fallback** — on `err 258` the client now
  iterates through all `KNOWN_APPS` (WatchPower, RenoClient, …), retrying
  `webQueryDeviceEs` with each profile. Only `app_id` and `app_version` are
  swapped; `company_key`, `base_url`, `locale` etc. are inherited from the
  configured app so network config stays correct for mock/testing.
- `self._app` stored so the fallback can compare the current profile
  against known ones.

### HA integration (`custom_components/shinemonitor/`)

- **`config_flow.py`** — app profile dropdown (`watchpower` / `renoclient`)
  in the setup form, validated during login.
- **`coordinator.py`** — reads `app_profile` from `ConfigEntry.data` and
  passes `AppProfile.from_name(app_profile)` to `AsyncShineMonitorAPI`.
- **`const.py`** — added `CONF_APP_PROFILE` / `DEFAULT_APP_PROFILE`.

## RenoClient constants — provenance

Reverse-engineered from `renoclient-1-3-2-0.apk`
(`com.eybond.smartclient.utils.VertifyUtils.getBaseAction` /
`WelcomeActivity.loginIn`): same backend, same `company-key`
(`bnrl_frRFjEz8Mkn`) as WatchPower — differs **only** in
`_app_id_=com.eybond.renoclient` and `_app_version_=1.3.2.0`.

## BREAKING CHANGE

Client constructors now take `app=AppProfile` instead of the
`base_url` / `suffix_context` / `company_key` kwargs:

```python
# before
ShineMonitorAPI(suffix_context=WATCHPOWER_SUFFIX_CONTEXT)
# after
ShineMonitorAPI(app=AppProfile.WATCHPOWER)   # or omit — it's the default
ShineMonitorAPI(app=AppProfile.RENOCLIENT)
```

No-arg construction is unchanged (defaults to WatchPower).

## Verification

- Python `71 passed` (existing fallback test adapted to cross-app retry)
- Go, Rust still pass against the shared mock
- mypy clean; full pre-commit (ruff, ruff-format, bandit, codespell) passes

Refs #4
